### PR TITLE
feat: add provider search and dashboard data

### DIFF
--- a/app/patient/providers/page.tsx
+++ b/app/patient/providers/page.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Input } from "@/components/ui/input"
+import { ProviderCard } from "@/components/provider/provider-card"
+import { ProviderProfile, supabase } from "@/lib/supabase"
+
+export default function ProviderSearchPage() {
+  const [providers, setProviders] = useState<ProviderProfile[]>([])
+  const [search, setSearch] = useState("")
+
+  useEffect(() => {
+    const fetchProviders = async () => {
+      const { data, error } = await supabase
+        .from("provider_profiles")
+        .select("*, users(full_name, avatar_url)")
+
+      if (!error && data) {
+        setProviders(data as any)
+      }
+    }
+    fetchProviders()
+  }, [])
+
+  const filtered = providers.filter((p) => {
+    const name = (p as any).users?.full_name || ""
+    const specialties = p.specialties?.join(" ") || ""
+    const location = p.location || ""
+    const term = search.toLowerCase()
+    return (
+      name.toLowerCase().includes(term) ||
+      specialties.toLowerCase().includes(term) ||
+      location.toLowerCase().includes(term)
+    )
+  })
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold tracking-tight">Find Providers</h1>
+      <Input
+        placeholder="Search by name, specialty, or location"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {filtered.map((provider) => (
+          <ProviderCard key={provider.id} provider={provider} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/provider/dashboard/page.tsx
+++ b/app/provider/dashboard/page.tsx
@@ -1,95 +1,77 @@
+"use client"
+
+import { useEffect, useState } from "react"
 import Link from "next/link"
-import { Activity, Calendar, CheckCircle2, Clock, Dumbbell, Users, XCircle } from 'lucide-react'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Calendar,
+  CheckCircle2,
+  Dumbbell,
+  Users,
+} from "lucide-react"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Progress } from "@/components/ui/progress"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { Badge } from "@/components/ui/badge"
+import { useAuth } from "@/hooks/use-auth"
+import { supabase } from "@/lib/supabase"
+
+interface PatientRow {
+  id: string
+  program_name: string
+  user_id: string
+  users: {
+    full_name: string
+    avatar_url: string | null
+  }
+}
 
 export default function ProviderDashboard() {
-  // Mock data
-  const stats = [
-    {
-      title: "Total Patients",
-      value: "42",
-      icon: Users,
-      change: "+3 this week",
-      trend: "up",
-    },
-    {
-      title: "Completed Sessions",
-      value: "128",
-      icon: CheckCircle2,
-      change: "+24 this week",
-      trend: "up",
-    },
-    {
-      title: "Missed Sessions",
-      value: "7",
-      icon: XCircle,
-      change: "-2 this week",
-      trend: "down",
-    },
-    {
-      title: "Exercise Library",
-      value: "156",
-      icon: Dumbbell,
-      change: "+5 this week",
-      trend: "up",
-    },
-  ]
+  const { user } = useAuth()
+  const [patients, setPatients] = useState<PatientRow[]>([])
+  const [stats, setStats] = useState({
+    totalPatients: 0,
+    completedSessions: 0,
+    exerciseCount: 0,
+  })
 
-  const upcomingSessions = [
-    {
-      patient: "Michael Smith",
-      time: "10:00 AM",
-      program: "Knee Rehabilitation",
-      avatar: "",
-    },
-    {
-      patient: "Emma Johnson",
-      time: "11:30 AM",
-      program: "Shoulder Mobility",
-      avatar: "",
-    },
-    {
-      patient: "David Wilson",
-      time: "2:15 PM",
-      program: "Lower Back Strength",
-      avatar: "",
-    },
-  ]
+  useEffect(() => {
+    if (user) {
+      fetchData()
+    }
+  }, [user])
 
-  const recentPatients = [
-    {
-      name: "Michael Smith",
-      program: "Knee Rehabilitation",
-      progress: 75,
-      lastSession: "Today",
-      avatar: "",
-    },
-    {
-      name: "Emma Johnson",
-      program: "Shoulder Mobility",
-      progress: 60,
-      lastSession: "Yesterday",
-      avatar: "",
-    },
-    {
-      name: "David Wilson",
-      program: "Lower Back Strength",
-      progress: 40,
-      lastSession: "2 days ago",
-      avatar: "",
-    },
-    {
-      name: "Sophia Brown",
-      program: "Ankle Stability",
-      progress: 90,
-      lastSession: "3 days ago",
-      avatar: "",
-    },
-  ]
+  const fetchData = async () => {
+    const { data: patientsData } = await supabase
+      .from("patients")
+      .select("id, program_name, user_id, users(full_name, avatar_url)")
+      .eq("provider_id", user!.id)
+
+    const patientList = (patientsData as any as PatientRow[]) || []
+    setPatients(patientList)
+
+    const patientIds = patientList.map((p) => p.id)
+
+    const { count: sessionCount } = await supabase
+      .from("exercise_sessions")
+      .select("id", { count: "exact", head: true })
+      .in("patient_id", patientIds.length ? patientIds : ["00000000-0000-0000-0000-000000000000"])
+
+    const { count: exerciseCount } = await supabase
+      .from("exercises")
+      .select("id", { count: "exact", head: true })
+
+    setStats({
+      totalPatients: patientList.length,
+      completedSessions: sessionCount || 0,
+      exerciseCount: exerciseCount || 0,
+    })
+  }
 
   return (
     <div className="space-y-6">
@@ -108,44 +90,50 @@ export default function ProviderDashboard() {
       </div>
 
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        {stats.map((stat) => (
-          <Card key={stat.title}>
-            <CardHeader className="flex flex-row items-center justify-between pb-2">
-              <CardTitle className="text-sm font-medium">
-                {stat.title}
-              </CardTitle>
-              <stat.icon className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{stat.value}</div>
-              <p className={`text-xs ${stat.trend === "up" ? "text-green-500" : "text-red-500"}`}>
-                {stat.change}
-              </p>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-
-      <div className="grid gap-4 md:grid-cols-2">
         <Card>
-          <CardHeader>
-            <CardTitle>Today's Sessions</CardTitle>
-            <CardDescription>
-              You have {upcomingSessions.length} sessions scheduled for today
-            </CardDescription>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-sm font-medium">Total Patients</CardTitle>
+            <Users className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="space-y-4">
-              {upcomingSessions.map((session) => (
-                <div
-                  key={session.patient}
-                  className="flex items-center justify-between space-x-4"
-                >
-                  <div className="flex items-center space-x-4">
-                    <Avatar>
-                      <AvatarImage src={session.avatar || "/placeholder.svg"} />
+            <div className="text-2xl font-bold">{stats.totalPatients}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-sm font-medium">Completed Sessions</CardTitle>
+            <CheckCircle2 className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{stats.completedSessions}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-sm font-medium">Exercise Library</CardTitle>
+            <Dumbbell className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{stats.exerciseCount}</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Patient Progress</CardTitle>
+          <CardDescription>Recent patient activity and progress</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {patients.map((patient) => (
+              <div key={patient.id} className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center space-x-2">
+                    <Avatar className="h-8 w-8">
+                      <AvatarImage src={patient.users.avatar_url || "/placeholder.svg"} />
                       <AvatarFallback>
-                        {session.patient
+                        {patient.users.full_name
                           .split(" ")
                           .map((n) => n[0])
                           .join("")}
@@ -153,87 +141,36 @@ export default function ProviderDashboard() {
                     </Avatar>
                     <div>
                       <p className="text-sm font-medium leading-none">
-                        {session.patient}
+                        {patient.users.full_name}
                       </p>
-                      <p className="text-sm text-muted-foreground">
-                        {session.program}
+                      <p className="text-xs text-muted-foreground">
+                        Program: {patient.program_name}
                       </p>
                     </div>
                   </div>
-                  <div className="flex items-center gap-2">
-                    <Badge variant="outline" className="flex items-center gap-1">
-                      <Clock className="h-3 w-3" />
-                      <span>{session.time}</span>
-                    </Badge>
-                    <Button size="sm" variant="ghost">
-                      View
-                    </Button>
-                  </div>
+                  <Button size="sm" variant="ghost">
+                    View
+                  </Button>
                 </div>
-              ))}
-            </div>
-            <div className="mt-4 flex justify-center">
-              <Link href="/provider/calendar">
-                <Button variant="outline" size="sm">
-                  View Full Schedule
-                </Button>
-              </Link>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Patient Progress</CardTitle>
-            <CardDescription>
-              Recent patient activity and progress
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-4">
-              {recentPatients.map((patient) => (
-                <div key={patient.name} className="space-y-2">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center space-x-2">
-                      <Avatar className="h-8 w-8">
-                        <AvatarImage src={patient.avatar || "/placeholder.svg"} />
-                        <AvatarFallback>
-                          {patient.name
-                            .split(" ")
-                            .map((n) => n[0])
-                            .join("")}
-                        </AvatarFallback>
-                      </Avatar>
-                      <div>
-                        <p className="text-sm font-medium leading-none">
-                          {patient.name}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          Last session: {patient.lastSession}
-                        </p>
-                      </div>
-                    </div>
-                    <Button size="sm" variant="ghost">
-                      View
-                    </Button>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Progress value={patient.progress} className="h-2" />
-                    <span className="text-xs font-medium">{patient.progress}%</span>
-                  </div>
+                <div className="flex items-center gap-2">
+                  <Progress value={0} className="h-2" />
+                  <span className="text-xs font-medium">0%</span>
                 </div>
-              ))}
-            </div>
-            <div className="mt-4 flex justify-center">
-              <Link href="/provider/patients">
-                <Button variant="outline" size="sm">
-                  View All Patients
-                </Button>
-              </Link>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+              </div>
+            ))}
+            {patients.length === 0 && (
+              <p className="text-sm text-muted-foreground">No patients yet.</p>
+            )}
+          </div>
+          <div className="mt-4 flex justify-center">
+            <Link href="/provider/patients">
+              <Button variant="outline" size="sm">
+                View All Patients
+              </Button>
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/components/provider/provider-card.tsx
+++ b/components/provider/provider-card.tsx
@@ -1,0 +1,51 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { ProviderProfile } from "@/lib/supabase"
+
+interface ProviderCardProps {
+  provider: ProviderProfile
+}
+
+export function ProviderCard({ provider }: ProviderCardProps) {
+  const user = (provider as any).users
+  const initials = user?.full_name
+    ? user.full_name
+        .split(" ")
+        .map((n: string) => n[0])
+        .join("")
+    : ""
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center gap-4">
+        <Avatar>
+          <AvatarImage src={user?.avatar_url || "/placeholder.svg"} />
+          <AvatarFallback>{initials}</AvatarFallback>
+        </Avatar>
+        <div>
+          <CardTitle>{user?.full_name}</CardTitle>
+          {provider.credentials && (
+            <p className="text-sm text-muted-foreground">{provider.credentials}</p>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {provider.bio && <p className="text-sm">{provider.bio}</p>}
+        <div className="flex flex-wrap gap-2">
+          {provider.specialties?.map((spec) => (
+            <Badge key={spec}>{spec}</Badge>
+          ))}
+        </div>
+        {provider.location && (
+          <p className="text-sm text-muted-foreground">Location: {provider.location}</p>
+        )}
+        {provider.rating && (
+          <p className="text-sm text-muted-foreground">Rating: {provider.rating}</p>
+        )}
+        <Button className="w-full" size="sm">View Profile</Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/sidebar-nav.tsx
+++ b/components/sidebar-nav.tsx
@@ -67,6 +67,11 @@ export function SidebarNav({ role }: SidebarNavProps) {
       icon: Dumbbell,
     },
     {
+      title: "Find Providers",
+      href: "/patient/providers",
+      icon: Users,
+    },
+    {
       title: "Progress",
       href: "/patient/progress",
       icon: BarChart3,

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -61,4 +61,19 @@ export interface Progress {
   target_value: number
   unit: string
   recorded_at: string
-} 
+}
+
+export interface ProviderProfile {
+  id: string
+  user_id: string
+  specialties: string[]
+  credentials: string | null
+  experience_years: number | null
+  availability: any
+  max_patients: number
+  rating: number | null
+  bio: string | null
+  location: string | null
+  created_at: string
+  users?: User
+}

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -12,6 +12,21 @@ CREATE TABLE public.users (
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
+-- Create provider_profiles table
+CREATE TABLE public.provider_profiles (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  specialties TEXT[],
+  credentials TEXT,
+  experience_years INTEGER,
+  availability JSONB,
+  max_patients INTEGER DEFAULT 50,
+  rating DECIMAL(3,2),
+  bio TEXT,
+  location TEXT,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
 -- Create patients table
 CREATE TABLE public.patients (
   id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
@@ -167,4 +182,21 @@ INSERT INTO public.exercises (name, description, category, body_region, difficul
 ('Quad Strengthening', 'Build strength in the quadriceps muscles', 'Strength', 'Knee', 'intermediate', 'Stand with your feet shoulder-width apart. Slowly lower into a squat position, keeping your knees behind your toes. Hold for 2 seconds, then return to standing.', 3, 10),
 ('Shoulder External Rotation', 'Improve shoulder mobility and strength', 'Mobility', 'Shoulder', 'beginner', 'Hold a resistance band with your elbow bent at 90 degrees. Rotate your forearm outward against the resistance. Control the movement back to starting position.', 3, 15),
 ('Hip Abduction', 'Strengthen hip abductor muscles', 'Strength', 'Hip', 'beginner', 'Lie on your side with your legs stacked. Lift your top leg up and away from your body, keeping it straight. Lower back down with control.', 3, 12),
-('Ankle Dorsiflexion', 'Improve ankle mobility and flexibility', 'Mobility', 'Ankle', 'beginner', 'Sit with your legs extended. Point your toes toward your shin, then flex them away. Repeat this movement slowly and controlled.', 3, 20); 
+('Ankle Dorsiflexion', 'Improve ankle mobility and flexibility', 'Mobility', 'Ankle', 'beginner', 'Sit with your legs extended. Point your toes toward your shin, then flex them away. Repeat this movement slowly and controlled.', 3, 20);
+
+-- Sample provider and patient data
+INSERT INTO public.users (id, email, full_name, role) VALUES
+('00000000-0000-0000-0000-000000000001', 'drsarah@example.com', 'Dr. Sarah Johnson', 'provider'),
+('00000000-0000-0000-0000-000000000002', 'john@example.com', 'John Smith', 'patient');
+
+INSERT INTO public.provider_profiles (user_id, specialties, credentials, experience_years, availability, max_patients, rating, bio, location) VALUES
+('00000000-0000-0000-0000-000000000001', ARRAY['Orthopedic'], 'PT, DPT', 10, '{}'::jsonb, 50, 4.9, 'Orthopedic specialist with 10 years of experience.', 'New York');
+
+INSERT INTO public.patients (user_id, provider_id, diagnosis, program_name, start_date, status) VALUES
+('00000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000001', 'Knee injury', 'Knee Rehab', NOW(), 'active');
+
+INSERT INTO public.exercise_sessions (patient_id, exercise_id, form_score, pain_level) VALUES
+((SELECT id FROM public.patients LIMIT 1), (SELECT id FROM public.exercises LIMIT 1), 80, 3);
+
+INSERT INTO public.progress (patient_id, metric_name, current_value, target_value, unit) VALUES
+((SELECT id FROM public.patients LIMIT 1), 'Strength', 50, 100, 'reps');


### PR DESCRIPTION
## Summary
- extend Supabase schema with provider profiles and seed sample provider/patient data
- add patient-facing provider search with filtering and provider cards
- wire provider dashboard to Supabase for live patient counts and stats

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration and exits)*

------
https://chatgpt.com/codex/tasks/task_e_68927f19344c8329bd5cb6dc5590a1bf