### PR TITLE
feat: add provider search and patient management tools

### DIFF
--- a/app/patient/dashboard/page.tsx
+++ b/app/patient/dashboard/page.tsx
@@ -62,10 +62,12 @@ export default function PatientDashboard() {
         ? Math.round(recentSessions.reduce((sum, session) => sum + (session.form_score || 0), 0) / recentSessions.length)
         : 0
 
-      // Fetch assigned exercises
+      // Fetch assigned exercises with custom sets/reps
       const { data: assignedExercises } = await supabase
         .from('patient_exercises')
         .select(`
+          sets,
+          reps,
           exercises (
             id,
             name,
@@ -78,7 +80,12 @@ export default function PatientDashboard() {
         .eq('is_active', true)
         .limit(3)
 
-      const exercises = (assignedExercises?.map(item => item.exercises).filter(Boolean) || []) as unknown as Exercise[]
+      const exercises =
+        (assignedExercises?.map((item: any) => ({
+          ...(item.exercises || {}),
+          sets: item.sets ?? item.exercises?.sets,
+          reps: item.reps ?? item.exercises?.reps,
+        })) || []) as Exercise[]
 
       // Fetch progress data
       const { data: progressData } = await supabase

--- a/app/patient/exercises/page.tsx
+++ b/app/patient/exercises/page.tsx
@@ -51,7 +51,8 @@ export default function PatientExercisesPage() {
       const { data: assignedExercises, error: assignedError } = await supabase
         .from('patient_exercises')
         .select(`
-          exercise_id,
+          sets,
+          reps,
           exercises (
             id,
             name,
@@ -75,7 +76,12 @@ export default function PatientExercisesPage() {
       }
 
       // Extract exercises from the joined data
-      const exerciseList = assignedExercises?.map(item => item.exercises).filter(Boolean) || []
+      const exerciseList =
+        (assignedExercises?.map((item: any) => ({
+          ...(item.exercises || {}),
+          sets: item.sets ?? item.exercises?.sets,
+          reps: item.reps ?? item.exercises?.reps,
+        })) || []) as Exercise[]
       setExercises(exerciseList)
     } catch (error) {
       console.error('Error fetching exercises:', error)

--- a/app/patient/messages/page.tsx
+++ b/app/patient/messages/page.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { ChatInterface } from "@/components/chat/chat-interface"
+import { useAuth } from "@/hooks/use-auth"
+import { supabase } from "@/lib/supabase"
+
+export default function PatientMessagesPage() {
+  const { user } = useAuth()
+  const [providerId, setProviderId] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (user) {
+      fetchProvider()
+    }
+  }, [user])
+
+  const fetchProvider = async () => {
+    const { data } = await supabase
+      .from('patients')
+      .select('provider_id')
+      .eq('user_id', user!.id)
+      .single()
+    setProviderId(data?.provider_id || null)
+  }
+
+  if (!providerId) {
+    return <div>No provider assigned.</div>
+  }
+
+  return (
+    <div className="h-full">
+      <ChatInterface peerId={providerId} />
+    </div>
+  )
+}
+

--- a/app/patient/providers/page.tsx
+++ b/app/patient/providers/page.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Input } from "@/components/ui/input"
+import { ProviderCard } from "@/components/provider/provider-card"
+import { ProviderProfile, supabase } from "@/lib/supabase"
+import { useAuth } from "@/hooks/use-auth"
+
+export default function ProviderSearchPage() {
+  const [providers, setProviders] = useState<ProviderProfile[]>([])
+  const [search, setSearch] = useState("")
+  const { user } = useAuth()
+
+  useEffect(() => {
+    const fetchProviders = async () => {
+      const { data, error } = await supabase
+        .from("provider_profiles")
+        .select("*, users(full_name, avatar_url)")
+
+      if (!error && data) {
+        setProviders(data as any)
+      }
+    }
+    fetchProviders()
+  }, [])
+
+  const filtered = providers.filter((p) => {
+    const name = (p as any).users?.full_name || ""
+    const specialties = p.specialties?.join(" ") || ""
+    const location = p.location || ""
+    const term = search.toLowerCase()
+    return (
+      name.toLowerCase().includes(term) ||
+      specialties.toLowerCase().includes(term) ||
+      location.toLowerCase().includes(term)
+    )
+  })
+
+  async function handleConnect(provider: ProviderProfile) {
+    if (!user) return
+    const { data: existing } = await supabase
+      .from('patients')
+      .select('id')
+      .eq('user_id', user.id)
+      .maybeSingle()
+
+    if (existing) {
+      await supabase.from('patients').update({ provider_id: provider.user_id }).eq('id', existing.id)
+    } else {
+      await supabase.from('patients').insert({
+        user_id: user.id,
+        provider_id: provider.user_id,
+        diagnosis: 'TBD',
+        program_name: 'General',
+        start_date: new Date().toISOString(),
+        status: 'active'
+      })
+    }
+    alert('Provider connected')
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold tracking-tight">Find Providers</h1>
+      <Input
+        placeholder="Search by name, specialty, or location"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {filtered.map((provider) => (
+          <ProviderCard key={provider.id} provider={provider} onConnect={handleConnect} />
+        ))}
+      </div>
+    </div>
+  )
+}
+

--- a/app/patient/schedule/page.tsx
+++ b/app/patient/schedule/page.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useAuth } from "@/hooks/use-auth"
+import { supabase } from "@/lib/supabase"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+interface Assignment {
+  id: string
+  sets: number
+  reps: number
+  exercises: {
+    name: string
+    description: string
+  }
+}
+
+export default function PatientSchedulePage() {
+  const { user } = useAuth()
+  const [assignments, setAssignments] = useState<Assignment[]>([])
+
+  useEffect(() => {
+    if (user) {
+      fetchAssignments()
+    }
+  }, [user])
+
+  const fetchAssignments = async () => {
+    const { data: patient } = await supabase
+      .from('patients')
+      .select('id')
+      .eq('user_id', user!.id)
+      .single()
+
+    if (!patient) return
+
+    const { data } = await supabase
+      .from('patient_exercises')
+      .select('id, sets, reps, exercises(name, description)')
+      .eq('patient_id', patient.id)
+      .eq('is_active', true)
+
+    setAssignments((data as any) || [])
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold tracking-tight">Schedule</h1>
+      <div className="space-y-4">
+        {assignments.map((a) => (
+          <Card key={a.id}>
+            <CardHeader>
+              <CardTitle>{a.exercises.name}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="mb-2 text-sm text-muted-foreground">{a.exercises.description}</p>
+              <p className="text-sm">Sets: {a.sets} Reps: {a.reps}</p>
+            </CardContent>
+          </Card>
+        ))}
+        {assignments.length === 0 && (
+          <p className="text-sm text-muted-foreground">No exercises scheduled.</p>
+        )}
+      </div>
+    </div>
+  )
+}
+

--- a/app/provider/dashboard/page.tsx
+++ b/app/provider/dashboard/page.tsx
@@ -1,95 +1,120 @@
+"use client"
+
+import { useEffect, useState } from "react"
 import Link from "next/link"
-import { Activity, Calendar, CheckCircle2, Clock, Dumbbell, Users, XCircle } from 'lucide-react'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Calendar,
+  CheckCircle2,
+  Dumbbell,
+  Users,
+} from "lucide-react"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Progress } from "@/components/ui/progress"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { Badge } from "@/components/ui/badge"
+import { useAuth } from "@/hooks/use-auth"
+import { supabase } from "@/lib/supabase"
+import { AssignExerciseDialog } from "@/components/provider/assign-exercise-dialog"
+
+interface PatientRow {
+  id: string
+  program_name: string
+  user_id: string
+  users: {
+    full_name: string
+    avatar_url: string | null
+  }
+}
+
+interface PatientWithStats extends PatientRow {
+  progress: number
+  completedSessions: number
+  totalAssignments: number
+  lastSession: string | null
+}
 
 export default function ProviderDashboard() {
-  // Mock data
-  const stats = [
-    {
-      title: "Total Patients",
-      value: "42",
-      icon: Users,
-      change: "+3 this week",
-      trend: "up",
-    },
-    {
-      title: "Completed Sessions",
-      value: "128",
-      icon: CheckCircle2,
-      change: "+24 this week",
-      trend: "up",
-    },
-    {
-      title: "Missed Sessions",
-      value: "7",
-      icon: XCircle,
-      change: "-2 this week",
-      trend: "down",
-    },
-    {
-      title: "Exercise Library",
-      value: "156",
-      icon: Dumbbell,
-      change: "+5 this week",
-      trend: "up",
-    },
-  ]
+  const { user } = useAuth()
+  const [patients, setPatients] = useState<PatientWithStats[]>([])
+  const [stats, setStats] = useState({
+    totalPatients: 0,
+    completedSessions: 0,
+    exerciseCount: 0,
+  })
 
-  const upcomingSessions = [
-    {
-      patient: "Michael Smith",
-      time: "10:00 AM",
-      program: "Knee Rehabilitation",
-      avatar: "",
-    },
-    {
-      patient: "Emma Johnson",
-      time: "11:30 AM",
-      program: "Shoulder Mobility",
-      avatar: "",
-    },
-    {
-      patient: "David Wilson",
-      time: "2:15 PM",
-      program: "Lower Back Strength",
-      avatar: "",
-    },
-  ]
+  useEffect(() => {
+    if (user) {
+      fetchData()
+    }
+  }, [user])
 
-  const recentPatients = [
-    {
-      name: "Michael Smith",
-      program: "Knee Rehabilitation",
-      progress: 75,
-      lastSession: "Today",
-      avatar: "",
-    },
-    {
-      name: "Emma Johnson",
-      program: "Shoulder Mobility",
-      progress: 60,
-      lastSession: "Yesterday",
-      avatar: "",
-    },
-    {
-      name: "David Wilson",
-      program: "Lower Back Strength",
-      progress: 40,
-      lastSession: "2 days ago",
-      avatar: "",
-    },
-    {
-      name: "Sophia Brown",
-      program: "Ankle Stability",
-      progress: 90,
-      lastSession: "3 days ago",
-      avatar: "",
-    },
-  ]
+  const fetchData = async () => {
+    const { data: patientsData } = await supabase
+      .from("patients")
+      .select("id, program_name, user_id, users(full_name, avatar_url)")
+      .eq("provider_id", user!.id)
+
+    const patientList = (patientsData as any as PatientRow[]) || []
+
+    const patientsWithStats: PatientWithStats[] = await Promise.all(
+      patientList.map(async (p) => {
+        const { count: assignmentCount } = await supabase
+          .from("patient_exercises")
+          .select("id", { count: "exact", head: true })
+          .eq("patient_id", p.id)
+
+        const { data: sessionData, count: completedCount } = await supabase
+          .from("exercise_sessions")
+          .select("completed_at", { count: "exact" })
+          .eq("patient_id", p.id)
+          .order("completed_at", { ascending: false })
+          .limit(1)
+
+        const lastSession = sessionData?.[0]?.completed_at || null
+        const progress = assignmentCount
+          ? Math.min(100, Math.round(((completedCount || 0) / assignmentCount) * 100))
+          : 0
+
+        return {
+          ...p,
+          progress,
+          completedSessions: completedCount || 0,
+          totalAssignments: assignmentCount || 0,
+          lastSession,
+        }
+      })
+    )
+
+    setPatients(patientsWithStats)
+
+    const patientIds = patientList.map((p) => p.id)
+
+    const { count: sessionCount } = await supabase
+      .from("exercise_sessions")
+      .select("id", { count: "exact", head: true })
+      .in(
+        "patient_id",
+        patientIds.length
+          ? patientIds
+          : ["00000000-0000-0000-0000-000000000000"]
+      )
+
+    const { count: exerciseCount } = await supabase
+      .from("exercises")
+      .select("id", { count: "exact", head: true })
+
+    setStats({
+      totalPatients: patientList.length,
+      completedSessions: sessionCount || 0,
+      exerciseCount: exerciseCount || 0,
+    })
+  }
 
   return (
     <div className="space-y-6">
@@ -108,44 +133,50 @@ export default function ProviderDashboard() {
       </div>
 
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        {stats.map((stat) => (
-          <Card key={stat.title}>
-            <CardHeader className="flex flex-row items-center justify-between pb-2">
-              <CardTitle className="text-sm font-medium">
-                {stat.title}
-              </CardTitle>
-              <stat.icon className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{stat.value}</div>
-              <p className={`text-xs ${stat.trend === "up" ? "text-green-500" : "text-red-500"}`}>
-                {stat.change}
-              </p>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-
-      <div className="grid gap-4 md:grid-cols-2">
         <Card>
-          <CardHeader>
-            <CardTitle>Today's Sessions</CardTitle>
-            <CardDescription>
-              You have {upcomingSessions.length} sessions scheduled for today
-            </CardDescription>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-sm font-medium">Total Patients</CardTitle>
+            <Users className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="space-y-4">
-              {upcomingSessions.map((session) => (
-                <div
-                  key={session.patient}
-                  className="flex items-center justify-between space-x-4"
-                >
-                  <div className="flex items-center space-x-4">
-                    <Avatar>
-                      <AvatarImage src={session.avatar || "/placeholder.svg"} />
+            <div className="text-2xl font-bold">{stats.totalPatients}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-sm font-medium">Completed Sessions</CardTitle>
+            <CheckCircle2 className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{stats.completedSessions}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-sm font-medium">Exercise Library</CardTitle>
+            <Dumbbell className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{stats.exerciseCount}</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Patient Progress</CardTitle>
+          <CardDescription>Recent patient activity and progress</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {patients.map((patient) => (
+              <div key={patient.id} className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center space-x-2">
+                    <Avatar className="h-8 w-8">
+                      <AvatarImage src={patient.users.avatar_url || "/placeholder.svg"} />
                       <AvatarFallback>
-                        {session.patient
+                        {patient.users.full_name
                           .split(" ")
                           .map((n) => n[0])
                           .join("")}
@@ -153,87 +184,50 @@ export default function ProviderDashboard() {
                     </Avatar>
                     <div>
                       <p className="text-sm font-medium leading-none">
-                        {session.patient}
+                        {patient.users.full_name}
                       </p>
-                      <p className="text-sm text-muted-foreground">
-                        {session.program}
+                      <p className="text-xs text-muted-foreground">
+                        Program: {patient.program_name}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {patient.lastSession
+                          ? `Last session ${new Date(patient.lastSession).toLocaleDateString()}`
+                          : "No sessions yet"}
                       </p>
                     </div>
                   </div>
                   <div className="flex items-center gap-2">
-                    <Badge variant="outline" className="flex items-center gap-1">
-                      <Clock className="h-3 w-3" />
-                      <span>{session.time}</span>
-                    </Badge>
-                    <Button size="sm" variant="ghost">
-                      View
-                    </Button>
+                    <AssignExerciseDialog patientId={patient.id} onAssigned={fetchData} />
+                    <Link href={`/provider/messages/${patient.user_id}`}>
+                      <Button size="sm" variant="ghost">Message</Button>
+                    </Link>
+                    <Link href={`/provider/patients/${patient.id}`}>
+                      <Button size="sm" variant="ghost">View</Button>
+                    </Link>
                   </div>
                 </div>
-              ))}
-            </div>
-            <div className="mt-4 flex justify-center">
-              <Link href="/provider/calendar">
-                <Button variant="outline" size="sm">
-                  View Full Schedule
-                </Button>
-              </Link>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Patient Progress</CardTitle>
-            <CardDescription>
-              Recent patient activity and progress
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-4">
-              {recentPatients.map((patient) => (
-                <div key={patient.name} className="space-y-2">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center space-x-2">
-                      <Avatar className="h-8 w-8">
-                        <AvatarImage src={patient.avatar || "/placeholder.svg"} />
-                        <AvatarFallback>
-                          {patient.name
-                            .split(" ")
-                            .map((n) => n[0])
-                            .join("")}
-                        </AvatarFallback>
-                      </Avatar>
-                      <div>
-                        <p className="text-sm font-medium leading-none">
-                          {patient.name}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          Last session: {patient.lastSession}
-                        </p>
-                      </div>
-                    </div>
-                    <Button size="sm" variant="ghost">
-                      View
-                    </Button>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Progress value={patient.progress} className="h-2" />
-                    <span className="text-xs font-medium">{patient.progress}%</span>
-                  </div>
+                <div className="flex items-center gap-2">
+                  <Progress value={patient.progress} className="h-2" />
+                  <span className="text-xs font-medium">{patient.progress}%</span>
                 </div>
-              ))}
-            </div>
-            <div className="mt-4 flex justify-center">
-              <Link href="/provider/patients">
-                <Button variant="outline" size="sm">
-                  View All Patients
-                </Button>
-              </Link>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+                <p className="text-xs text-muted-foreground">
+                  Completed {patient.completedSessions} / {patient.totalAssignments}
+                </p>
+              </div>
+            ))}
+            {patients.length === 0 && (
+              <p className="text-sm text-muted-foreground">No patients yet.</p>
+            )}
+          </div>
+          <div className="mt-4 flex justify-center">
+            <Link href="/provider/patients">
+              <Button variant="outline" size="sm">
+                View All Patients
+              </Button>
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/app/provider/messages/[patientId]/page.tsx
+++ b/app/provider/messages/[patientId]/page.tsx
@@ -1,0 +1,10 @@
+import { ChatInterface } from "@/components/chat/chat-interface"
+
+export default function ProviderChatPage({ params }: { params: { patientId: string } }) {
+  return (
+    <div className="h-full">
+      <ChatInterface peerId={params.patientId} />
+    </div>
+  )
+}
+

--- a/app/provider/messages/page.tsx
+++ b/app/provider/messages/page.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { useAuth } from "@/hooks/use-auth"
+import { supabase } from "@/lib/supabase"
+
+interface PatientRow {
+  id: string
+  user_id: string
+  users: { full_name: string }
+}
+
+export default function ProviderMessagesPage() {
+  const { user } = useAuth()
+  const [patients, setPatients] = useState<PatientRow[]>([])
+
+  useEffect(() => {
+    if (user) {
+      fetchPatients()
+    }
+  }, [user])
+
+  const fetchPatients = async () => {
+    const { data } = await supabase
+      .from('patients')
+      .select('id, user_id, users(full_name)')
+      .eq('provider_id', user!.id)
+    setPatients((data as any) || [])
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold tracking-tight">Messages</h1>
+      <ul className="space-y-2">
+        {patients.map((p) => (
+          <li key={p.id}>
+            <Link className="text-primary underline" href={`/provider/messages/${p.user_id}`}>
+              {p.users.full_name}
+            </Link>
+          </li>
+        ))}
+        {patients.length === 0 && (
+          <p className="text-sm text-muted-foreground">No patients.</p>
+        )}
+      </ul>
+    </div>
+  )
+}
+

--- a/components/chat/chat-interface.tsx
+++ b/components/chat/chat-interface.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useAuth } from "@/hooks/use-auth"
+import { supabase, Message } from "@/lib/supabase"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+
+interface ChatInterfaceProps {
+  peerId: string
+}
+
+export function ChatInterface({ peerId }: ChatInterfaceProps) {
+  const { user } = useAuth()
+  const [messages, setMessages] = useState<Message[]>([])
+  const [content, setContent] = useState("")
+
+  useEffect(() => {
+    if (user && peerId) {
+      fetchMessages()
+    }
+  }, [user, peerId])
+
+  const fetchMessages = async () => {
+    const { data } = await supabase
+      .from("messages")
+      .select("*")
+      .or(
+        `and(sender_id.eq.${user!.id},receiver_id.eq.${peerId}),and(sender_id.eq.${peerId},receiver_id.eq.${user!.id})`
+      )
+      .order("created_at", { ascending: true })
+    setMessages((data as Message[]) || [])
+  }
+
+  const sendMessage = async () => {
+    if (!content.trim() || !user) return
+    await supabase.from("messages").insert({
+      sender_id: user.id,
+      receiver_id: peerId,
+      content,
+    })
+    setContent("")
+    fetchMessages()
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex-1 space-y-2 overflow-y-auto mb-4">
+        {messages.map((m) => (
+          <div
+            key={m.id}
+            className={`flex ${m.sender_id === user?.id ? "justify-end" : "justify-start"}`}
+          >
+            <div
+              className={`rounded-lg px-3 py-2 text-sm ${
+                m.sender_id === user?.id
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-muted"
+              }`}
+            >
+              {m.content}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <Input
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="Type a message"
+        />
+        <Button onClick={sendMessage}>Send</Button>
+      </div>
+    </div>
+  )
+}
+

--- a/components/provider/assign-exercise-dialog.tsx
+++ b/components/provider/assign-exercise-dialog.tsx
@@ -1,0 +1,93 @@
+import { useState, useEffect } from "react"
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogFooter } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select"
+import { Input } from "@/components/ui/input"
+import { supabase } from "@/lib/supabase"
+import { useAuth } from "@/hooks/use-auth"
+import { Exercise } from "@/lib/supabase"
+
+interface Props {
+  patientId: string
+  onAssigned: () => void
+}
+
+export function AssignExerciseDialog({ patientId, onAssigned }: Props) {
+  const { user } = useAuth()
+  const [open, setOpen] = useState(false)
+  const [exercises, setExercises] = useState<Pick<Exercise, "id" | "name">[]>([])
+  const [exerciseId, setExerciseId] = useState<string>("")
+  const [sets, setSets] = useState("")
+  const [reps, setReps] = useState("")
+
+  useEffect(() => {
+    if (open) {
+      supabase
+        .from("exercises")
+        .select("id, name")
+        .then(({ data }) => setExercises(data || []))
+    }
+  }, [open])
+
+  const handleAssign = async () => {
+    if (!exerciseId || !sets || !reps || !user) return
+    await supabase.from("patient_exercises").insert({
+      patient_id: patientId,
+      exercise_id: exerciseId,
+      sets: Number(sets),
+      reps: Number(reps),
+      assigned_by: user.id,
+    })
+    setExerciseId("")
+    setSets("")
+    setReps("")
+    setOpen(false)
+    onAssigned()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="outline">
+          Assign Exercise
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Assign Exercise</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          <Select value={exerciseId} onValueChange={setExerciseId}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select exercise" />
+            </SelectTrigger>
+            <SelectContent>
+              {exercises.map((ex) => (
+                <SelectItem key={ex.id} value={ex.id}>
+                  {ex.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <div className="grid grid-cols-2 gap-4">
+            <Input
+              type="number"
+              placeholder="Sets"
+              value={sets}
+              onChange={(e) => setSets(e.target.value)}
+            />
+            <Input
+              type="number"
+              placeholder="Reps"
+              value={reps}
+              onChange={(e) => setReps(e.target.value)}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button onClick={handleAssign}>Assign</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/provider/provider-card.tsx
+++ b/components/provider/provider-card.tsx
@@ -1,0 +1,58 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { ProviderProfile } from "@/lib/supabase"
+
+interface ProviderCardProps {
+  provider: ProviderProfile
+  onConnect?: (provider: ProviderProfile) => void
+}
+
+export function ProviderCard({ provider, onConnect }: ProviderCardProps) {
+  const user = (provider as any).users
+  const initials = user?.full_name
+    ? user.full_name
+        .split(" ")
+        .map((n: string) => n[0])
+        .join("")
+    : ""
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center gap-4">
+        <Avatar>
+          <AvatarImage src={user?.avatar_url || "/placeholder.svg"} />
+          <AvatarFallback>{initials}</AvatarFallback>
+        </Avatar>
+        <div>
+          <CardTitle>{user?.full_name}</CardTitle>
+          {provider.credentials && (
+            <p className="text-sm text-muted-foreground">{provider.credentials}</p>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {provider.bio && <p className="text-sm">{provider.bio}</p>}
+        <div className="flex flex-wrap gap-2">
+          {provider.specialties?.map((spec) => (
+            <Badge key={spec}>{spec}</Badge>
+          ))}
+        </div>
+        {provider.location && (
+          <p className="text-sm text-muted-foreground">Location: {provider.location}</p>
+        )}
+        {provider.rating && (
+          <p className="text-sm text-muted-foreground">Rating: {provider.rating}</p>
+        )}
+        {onConnect ? (
+          <Button className="w-full" size="sm" onClick={() => onConnect(provider)}>
+            Connect
+          </Button>
+        ) : (
+          <Button className="w-full" size="sm">View Profile</Button>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/sidebar-nav.tsx
+++ b/components/sidebar-nav.tsx
@@ -67,6 +67,11 @@ export function SidebarNav({ role }: SidebarNavProps) {
       icon: Dumbbell,
     },
     {
+      title: "Find Providers",
+      href: "/patient/providers",
+      icon: Users,
+    },
+    {
       title: "Progress",
       href: "/patient/progress",
       icon: BarChart3,

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -61,4 +61,38 @@ export interface Progress {
   target_value: number
   unit: string
   recorded_at: string
-} 
+}
+
+export interface PatientExercise {
+  id: string
+  patient_id: string
+  exercise_id: string
+  assigned_by: string
+  assigned_at: string
+  is_active: boolean
+  sets: number
+  reps: number
+}
+
+export interface ProviderProfile {
+  id: string
+  user_id: string
+  specialties: string[]
+  credentials: string | null
+  experience_years: number | null
+  availability: any
+  max_patients: number
+  rating: number | null
+  bio: string | null
+  location: string | null
+  created_at: string
+  users?: User
+}
+
+export interface Message {
+  id: string
+  sender_id: string
+  receiver_id: string
+  content: string
+  created_at: string
+}

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -1,6 +1,3 @@
--- Enable Row Level Security
-ALTER DATABASE postgres SET "app.jwt_secret" TO 'your-jwt-secret';
-
 -- Create users table (extends Supabase auth.users)
 CREATE TABLE public.users (
   id UUID REFERENCES auth.users(id) ON DELETE CASCADE PRIMARY KEY,

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -12,6 +12,21 @@ CREATE TABLE public.users (
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
+-- Create provider_profiles table
+CREATE TABLE public.provider_profiles (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  specialties TEXT[],
+  credentials TEXT,
+  experience_years INTEGER,
+  availability JSONB,
+  max_patients INTEGER DEFAULT 50,
+  rating DECIMAL(3,2),
+  bio TEXT,
+  location TEXT,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
 -- Create patients table
 CREATE TABLE public.patients (
   id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
@@ -75,10 +90,21 @@ CREATE TABLE public.patient_exercises (
   id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
   patient_id UUID REFERENCES public.patients(id) ON DELETE CASCADE NOT NULL,
   exercise_id UUID REFERENCES public.exercises(id) ON DELETE CASCADE NOT NULL,
+  sets INTEGER NOT NULL,
+  reps INTEGER NOT NULL,
   assigned_by UUID REFERENCES public.users(id) NOT NULL,
   assigned_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   is_active BOOLEAN DEFAULT true,
   UNIQUE(patient_id, exercise_id)
+);
+
+-- Create messages table
+CREATE TABLE public.messages (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  sender_id UUID REFERENCES public.users(id) ON DELETE CASCADE NOT NULL,
+  receiver_id UUID REFERENCES public.users(id) ON DELETE CASCADE NOT NULL,
+  content TEXT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
 -- Enable Row Level Security
@@ -88,6 +114,7 @@ ALTER TABLE public.exercises ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.exercise_sessions ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.progress ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.patient_exercises ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.messages ENABLE ROW LEVEL SECURITY;
 
 -- RLS Policies for users
 CREATE POLICY "Users can view their own profile" ON public.users
@@ -152,6 +179,15 @@ CREATE POLICY "Providers can manage patient exercises" ON public.patient_exercis
     auth.uid() = (SELECT provider_id FROM public.patients WHERE id = patient_id)
   );
 
+-- RLS Policies for messages
+CREATE POLICY "Users can view their messages" ON public.messages
+  FOR SELECT USING (
+    auth.uid() = sender_id OR auth.uid() = receiver_id
+  );
+
+CREATE POLICY "Users can send messages" ON public.messages
+  FOR INSERT WITH CHECK (auth.uid() = sender_id);
+
 -- Create indexes for better performance
 CREATE INDEX idx_patients_provider_id ON public.patients(provider_id);
 CREATE INDEX idx_patients_user_id ON public.patients(user_id);
@@ -159,6 +195,8 @@ CREATE INDEX idx_exercise_sessions_patient_id ON public.exercise_sessions(patien
 CREATE INDEX idx_exercise_sessions_exercise_id ON public.exercise_sessions(exercise_id);
 CREATE INDEX idx_progress_patient_id ON public.progress(patient_id);
 CREATE INDEX idx_patient_exercises_patient_id ON public.patient_exercises(patient_id);
+CREATE INDEX idx_messages_sender_id ON public.messages(sender_id);
+CREATE INDEX idx_messages_receiver_id ON public.messages(receiver_id);
 
 -- Insert sample data
 INSERT INTO public.exercises (name, description, category, body_region, difficulty, instructions, sets, reps) VALUES
@@ -167,4 +205,24 @@ INSERT INTO public.exercises (name, description, category, body_region, difficul
 ('Quad Strengthening', 'Build strength in the quadriceps muscles', 'Strength', 'Knee', 'intermediate', 'Stand with your feet shoulder-width apart. Slowly lower into a squat position, keeping your knees behind your toes. Hold for 2 seconds, then return to standing.', 3, 10),
 ('Shoulder External Rotation', 'Improve shoulder mobility and strength', 'Mobility', 'Shoulder', 'beginner', 'Hold a resistance band with your elbow bent at 90 degrees. Rotate your forearm outward against the resistance. Control the movement back to starting position.', 3, 15),
 ('Hip Abduction', 'Strengthen hip abductor muscles', 'Strength', 'Hip', 'beginner', 'Lie on your side with your legs stacked. Lift your top leg up and away from your body, keeping it straight. Lower back down with control.', 3, 12),
-('Ankle Dorsiflexion', 'Improve ankle mobility and flexibility', 'Mobility', 'Ankle', 'beginner', 'Sit with your legs extended. Point your toes toward your shin, then flex them away. Repeat this movement slowly and controlled.', 3, 20); 
+('Ankle Dorsiflexion', 'Improve ankle mobility and flexibility', 'Mobility', 'Ankle', 'beginner', 'Sit with your legs extended. Point your toes toward your shin, then flex them away. Repeat this movement slowly and controlled.', 3, 20);
+
+-- Sample provider and patient data
+INSERT INTO public.users (id, email, full_name, role) VALUES
+('00000000-0000-0000-0000-000000000001', 'drsarah@example.com', 'Dr. Sarah Johnson', 'provider'),
+('00000000-0000-0000-0000-000000000002', 'john@example.com', 'John Smith', 'patient');
+
+INSERT INTO public.provider_profiles (user_id, specialties, credentials, experience_years, availability, max_patients, rating, bio, location) VALUES
+('00000000-0000-0000-0000-000000000001', ARRAY['Orthopedic'], 'PT, DPT', 10, '{}'::jsonb, 50, 4.9, 'Orthopedic specialist with 10 years of experience.', 'New York');
+
+INSERT INTO public.patients (user_id, provider_id, diagnosis, program_name, start_date, status) VALUES
+('00000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000001', 'Knee injury', 'Knee Rehab', NOW(), 'active');
+
+INSERT INTO public.exercise_sessions (patient_id, exercise_id, form_score, pain_level) VALUES
+((SELECT id FROM public.patients LIMIT 1), (SELECT id FROM public.exercises LIMIT 1), 80, 3);
+
+INSERT INTO public.progress (patient_id, metric_name, current_value, target_value, unit) VALUES
+((SELECT id FROM public.patients LIMIT 1), 'Strength', 50, 100, 'reps');
+
+INSERT INTO public.patient_exercises (patient_id, exercise_id, sets, reps, assigned_by) VALUES
+((SELECT id FROM public.patients LIMIT 1), (SELECT id FROM public.exercises LIMIT 1), 3, 12, '00000000-0000-0000-0000-000000000001');


### PR DESCRIPTION
## Summary
- extend patient_exercises schema with set and rep counts and seed sample assignment
- update patient views and types to surface custom sets and reps from assignments
- expand provider dashboard with per-patient progress and an exercise assignment dialog
- add messaging system and patient schedule view for assigned exercises

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration and exits)*

------
https://chatgpt.com/codex/tasks/task_e_68927f19344c8329bd5cb6dc5590a1bf